### PR TITLE
[IMP] Validate that the code has no value and then, to create a new code to the claim. Because there are inheritance of the copy method where depending on the claim type and then the code is assigned, and that value is overwriting in this method.

### DIFF
--- a/crm_claim_code/models/crm_claim.py
+++ b/crm_claim_code/models/crm_claim.py
@@ -27,5 +27,6 @@ class CrmClaim(models.Model):
     def copy(self, default=None):
         if default is None:
             default = {}
-        default['code'] = self.env['ir.sequence'].get('crm.claim')
+        if 'code' not in default or default['code'] == '/':
+            default['code'] = self.env['ir.sequence'].get('crm.claim')
         return super(CrmClaim, self).copy(default)


### PR DESCRIPTION
### [Video with bug](https://youtu.be/glUch58sW-g)

When the method copy is called, i.e a claim is duplicated, the code is not set correctly, because there is a copy method that create one sequence and here is overwriting.

The generation of code depending on the[ claim type here](https://github.com/Vauxoo/rma/pull/128) and then the code is assigned, and that value is overwriting in this method.
