### PR TITLE
[IMP] crm_lead_currency: update field customer_currency_id to be shown in Lead an opportunity views T#70975

### DIFF
--- a/crm_lead_currency/views/crm_lead_views.xml
+++ b/crm_lead_currency/views/crm_lead_views.xml
@@ -6,14 +6,28 @@
         <field name="model">crm.lead</field>
         <field name="inherit_id" ref="crm.crm_lead_view_form" />
         <field name="arch" type="xml">
-            <field name="partner_id" position="before">
+            <xpath
+                expr="//group[@name='lead_partner']//field[@name='partner_id']"
+                position="before"
+            >
                 <field name="customer_currency_id" />
                 <field name="is_same_currency" invisible="1" />
                 <field
                     name="amount_customer_currency"
                     attrs="{'invisible': [('is_same_currency', '=', True)]}"
                 />
-            </field>
+            </xpath>
+            <xpath
+                expr="//group[@name='opportunity_partner']//field[@name='partner_id']"
+                position="before"
+            >
+                <field name="customer_currency_id" />
+                <field name="is_same_currency" invisible="1" />
+                <field
+                    name="amount_customer_currency"
+                    attrs="{'invisible': [('is_same_currency', '=', True)]}"
+                />
+            </xpath>
             <field name="expected_revenue" position="attributes">
                 <attribute name="attrs">
                     {'readonly': [('is_same_currency', '=', False)]}


### PR DESCRIPTION
Update fields customer_currency_id and amount_customer_currency to be shown in both views of Lead and in an Opportunity of CRM.

<img width="1303" alt="image" src="https://user-images.githubusercontent.com/77296309/236859045-42c99f11-5d90-4849-8367-ba3eafbb2674.png">

<img width="1293" alt="image" src="https://user-images.githubusercontent.com/77296309/236858983-59c8d5d4-63c4-448a-ba04-ab1484c44e90.png">
